### PR TITLE
Use field wp:post_date instead of wp:post_date_gmt for parsing. Fixes #1

### DIFF
--- a/zinnia_wordpress/management/commands/wp2zinnia.py
+++ b/zinnia_wordpress/management/commands/wp2zinnia.py
@@ -285,7 +285,7 @@ class Command(LabelCommand):
         wich is always in Wordpress $post->post_date.
         """
         creation_date = datetime.strptime(
-            item_node.find('{%s}post_date_gmt' % WP_NS).text,
+            item_node.find('{%s}post_date' % WP_NS).text,
             '%Y-%m-%d %H:%M:%S')
         if settings.USE_TZ:
             creation_date = timezone.make_aware(


### PR DESCRIPTION
For draft blog entries, the field wp:post_date_gmt is not populated leading to a ValueError.
The field wp:post_date and wp:post_date_gmt contain the same value for non-draft entries.

@Fantomas42 Please review. 
